### PR TITLE
Fix qt5.9 c++17

### DIFF
--- a/src/wrapper/quabasevariable.cpp
+++ b/src/wrapper/quabasevariable.cpp
@@ -263,7 +263,11 @@ void QUaBaseVariable::setDataTypeEnum(const QMetaEnum & metaEnum)
 	Q_CHECK_PTR(m_qUaServer);
 	Q_ASSERT(!UA_NodeId_isNull(&m_nodeId));
 	// compose enum name
-	QString strEnumName = QString("%1::%2").arg(metaEnum.scope()).arg(metaEnum.enumName());
+	#if QT_VERSION >= 0x051200
+		QString strEnumName = QString("%1::%2").arg(metaEnum.scope()).arg(metaEnum.enumName());
+	#else
+		QString strEnumName = QString("%1::%2").arg(metaEnum.scope()).arg(metaEnum.name());
+	#endif
 	// register if not exists
 	if (!m_qUaServer->m_hashEnums.contains(strEnumName))
 	{

--- a/src/wrapper/quaserver.cpp
+++ b/src/wrapper/quaserver.cpp
@@ -1093,7 +1093,11 @@ void QUaServer::registerType(const QMetaObject &metaObject, const QString &strNo
 void QUaServer::registerEnum(const QMetaEnum & metaEnum, const QString &strNodeId/* = ""*/)
 {
 	// compose enum name
-	QString strBrowseName = QString("%1::%2").arg(metaEnum.scope()).arg(metaEnum.enumName());
+	#if QT_VERSION >= 0x051200
+		QString strBrowseName = QString("%1::%2").arg(metaEnum.scope()).arg(metaEnum.enumName());
+	#else
+		QString strBrowseName = QString("%1::%2").arg(metaEnum.scope()).arg(metaEnum.name());
+	#endif
 	// compose values
 	QUaEnumMap mapEnum;
 	for (int i = 0; i < metaEnum.keyCount(); i++)
@@ -1165,7 +1169,11 @@ void QUaServer::addMetaProperties(const QMetaObject & parentMetaObject)
 		{
 			QMetaEnum metaEnum = metaProperty.enumerator();
 			// compose enum name
-			QString strEnumName = QString("%1::%2").arg(metaEnum.scope()).arg(metaEnum.enumName());
+			#if QT_VERSION >= 0x051200
+				QString strEnumName = QString("%1::%2").arg(metaEnum.scope()).arg(metaEnum.enumName());
+			#else
+				QString strEnumName = QString("%1::%2").arg(metaEnum.scope()).arg(metaEnum.name());
+			#endif
 			// must already be registered by now
 			Q_ASSERT(m_hashEnums.contains(strEnumName));
 			// get enum data type

--- a/src/wrapper/quaserver.h
+++ b/src/wrapper/quaserver.h
@@ -480,7 +480,11 @@ struct QUaMethodTraitsBase
     {
         QMetaEnum metaEnum = QMetaEnum::fromType<T>();
         // compose enum name
-        QString strEnumName = QString("%1::%2").arg(metaEnum.scope()).arg(metaEnum.enumName());
+        #if QT_VERSION >= 0x051200
+            QString strEnumName = QString("%1::%2").arg(metaEnum.scope()).arg(metaEnum.enumName());
+        #else
+            QString strEnumName = QString("%1::%2").arg(metaEnum.scope()).arg(metaEnum.name());
+        #endif
         // register if not exists
         if (!uaServer->m_hashEnums.contains(strEnumName))
         {

--- a/src/wrapper/quaserver.h
+++ b/src/wrapper/quaserver.h
@@ -461,8 +461,8 @@ struct QUaMethodTraitsBase
 	template<typename T>
 	inline static UA_Argument getTypeUaArgumentInternalArray(std::true_type, QUaServer * uaServer, const int &iArg = 0)
 	{
-		UA_Argument arg = getTypeUaArgumentInternalEnum<template_traits<T>::inner_type>
-			(std::is_enum<template_traits<T>::inner_type>(), uaServer, iArg);
+		UA_Argument arg = getTypeUaArgumentInternalEnum<typename template_traits<T>::inner_type>
+			(std::is_enum<typename template_traits<T>::inner_type>(), uaServer, iArg);
 		arg.valueRank = UA_VALUERANK_ONE_DIMENSION;
 		return arg;
 	}
@@ -538,7 +538,7 @@ struct QUaMethodTraitsBase
 	template<typename T>
 	inline static UA_Argument getRetUaArgumentArray(std::true_type)
 	{
-		UA_Argument arg = getRetUaArgumentArray<template_traits<T>::inner_type>(is_template<template_traits<T>::inner_type>());
+		UA_Argument arg = getRetUaArgumentArray<typename template_traits<T>::inner_type>(is_template<typename template_traits<T>::inner_type>());
 		arg.valueRank = UA_VALUERANK_ONE_DIMENSION;
 		return arg;
 	}


### PR DESCRIPTION
Thanks you for your wonderful wrapper! This branch fixes compilation with c++17 and qt5.9.

[enumName](https://doc.qt.io/qt-5/qmetaenum.html#enumName) was only introduced in Qt 5.12.
Not sure whether simply replacing `enumName()` with `name()` is okay, you will know better.

