### PR TITLE
make QUaNode::m_qUaServer protected rather than private (fixes clang …

### DIFF
--- a/src/wrapper/quanode.h
+++ b/src/wrapper/quanode.h
@@ -316,10 +316,11 @@ signals:
 	void referenceAdded  (const QUaReference & ref, QUaNode * nodeTarget, const bool &isForward);
 	void referenceRemoved(const QUaReference & ref, QUaNode * nodeTarget, const bool &isForward);
 
-private:
-
+protected:
 	// to be able to reuse methods in subclasses
 	QUaServer * m_qUaServer;
+
+private:
 	// INSTANCE NodeId
 	UA_NodeId m_nodeId;
 


### PR DESCRIPTION
…error)

This was the error message:

../src/other/QUaServer/src/wrapper/quaserver.h:392:12: error:
'm_qUaServer' is a private member of 'QUaNode'
    return m_qUaServer->createInstance<T>(this, strNodeId);
           ^
../src/other/QUaServer/src/wrapper/quanode.h:317:14: note: declared
private here
        QUaServer * m_qUaServer;
                    ^