### PR TITLE
resurrect image datatype (somewhat)

### DIFF
--- a/src/wrapper/quacustomdatatypes.cpp
+++ b/src/wrapper/quacustomdatatypes.cpp
@@ -40,9 +40,9 @@ QHash<QString, QMetaType::Type> QUaDataType::m_custTypesByName = {
 	{QString("QUaStatusCode")             , QMetaType_StatusCode             },
 	{QString("QUaQualifiedName")          , QMetaType_QualifiedName          },
 	{QString("QUaLocalizedText")          , QMetaType_LocalizedText          },
-	// TODO : image
-	//{QString("QImage")                    , QMetaType_Image                  },
 #ifdef UA_GENERATED_NAMESPACE_ZERO_FULL
+	// TODO : image
+	{QString("QImage")                    , QMetaType_Image                  },
 	{QString("QUaOptionSet")              , QMetaType_OptionSet              },
 #endif // UA_GENERATED_NAMESPACE_ZERO_FULL
 #ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS
@@ -76,9 +76,8 @@ QHash<UA_NodeId, QMetaType::Type> QUaDataType::m_custTypesByNodeId = {
 	{UA_NODEID_NUMERIC(0, UA_NS0ID_STATUSCODE)                  , QMetaType_StatusCode             },
 	{UA_NODEID_NUMERIC(0, UA_NS0ID_QUALIFIEDNAME)               , QMetaType_QualifiedName          },
 	{UA_NODEID_NUMERIC(0, UA_NS0ID_LOCALIZEDTEXT)               , QMetaType_LocalizedText          },
-	// TODO : image
-	//{UA_NODEID_NUMERIC(0, UA_NS0ID_IMAGE)                       , QMetaType_Image                  },
 #ifdef UA_GENERATED_NAMESPACE_ZERO_FULL
+	{UA_NODEID_NUMERIC(0, UA_NS0ID_IMAGE)                       , QMetaType_Image                  },
 	{UA_NODEID_NUMERIC(0, UA_NS0ID_OPTIONSET)                   , QMetaType_OptionSet              },
 #endif // UA_GENERATED_NAMESPACE_ZERO_FULL
 #ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS
@@ -111,9 +110,8 @@ QHash<int, QMetaType::Type> QUaDataType::m_custTypesByTypeIndex = {
 	{UA_TYPES_STATUSCODE                  , QMetaType_StatusCode             },
 	{UA_TYPES_QUALIFIEDNAME               , QMetaType_QualifiedName          },
 	{UA_TYPES_LOCALIZEDTEXT               , QMetaType_LocalizedText          },
-	// TODO : image
-	//{UA_TYPES_IMAGEPNG                    , QMetaType_Image                  },
 #ifdef UA_GENERATED_NAMESPACE_ZERO_FULL
+	{UA_TYPES_IMAGEPNG                    , QMetaType_Image                  },
 	{UA_TYPES_OPTIONSET                   , QMetaType_OptionSet              },
 #endif // UA_GENERATED_NAMESPACE_ZERO_FULL
 #ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS
@@ -147,9 +145,9 @@ QHash<QMetaType::Type, QUaDataType::TypeData> QUaDataType::m_custTypesByType = {
 	{ QMetaType_StatusCode              , {QString("QUaStatusCode")              , UA_NODEID_NUMERIC(0, UA_NS0ID_STATUSCODE)                  , &UA_TYPES[UA_TYPES_STATUSCODE                  ]} },
 	{ QMetaType_QualifiedName           , {QString("QUaQualifiedName")           , UA_NODEID_NUMERIC(0, UA_NS0ID_QUALIFIEDNAME)               , &UA_TYPES[UA_TYPES_QUALIFIEDNAME               ]} },
 	{ QMetaType_LocalizedText           , {QString("QUaLocalizedText")           , UA_NODEID_NUMERIC(0, UA_NS0ID_LOCALIZEDTEXT)               , &UA_TYPES[UA_TYPES_LOCALIZEDTEXT               ]} },
-	// TODO : image
-	//{ QMetaType_Image                   , {QString("QImage")                     , UA_NODEID_NUMERIC(0, UA_NS0ID_IMAGE)                       , &UA_TYPES[UA_TYPES_IMAGEPNG                    ]} },
 #ifdef UA_GENERATED_NAMESPACE_ZERO_FULL
+	// TODO : image
+	{ QMetaType_Image                   , {QString("QImage")                     , UA_NODEID_NUMERIC(0, UA_NS0ID_IMAGE)                       , &UA_TYPES[UA_TYPES_IMAGEPNG                    ]} },
 	{ QMetaType_OptionSet               , {QString("QUaOptionSet")              , UA_NODEID_NUMERIC(0, UA_NS0ID_OPTIONSET)                    , &UA_TYPES[UA_TYPES_OPTIONSET                   ]} },
 #endif // UA_GENERATED_NAMESPACE_ZERO_FULL
 #ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS

--- a/src/wrapper/quacustomdatatypes.h
+++ b/src/wrapper/quacustomdatatypes.h
@@ -333,8 +333,6 @@ union QUaEventNotifier
 #define QMetaType_QualifiedName static_cast<QMetaType::Type>(qMetaTypeId<QUaQualifiedName>())
 #define QMetaType_LocalizedText static_cast<QMetaType::Type>(qMetaTypeId<QUaLocalizedText>())
 #define QMetaType_DataType      static_cast<QMetaType::Type>(qMetaTypeId<QUaDataType     >())
-// TODO :image
-//#define QMetaType_Image                   static_cast<QMetaType::Type>(qMetaTypeId<QImage>())
 
 // custom list types
 #define QMetaType_List_NodeId        static_cast<QMetaType::Type>(qMetaTypeId<QList<QUaNodeId       >>())
@@ -344,6 +342,7 @@ union QUaEventNotifier
 #define QMetaType_List_DataType      static_cast<QMetaType::Type>(qMetaTypeId<QList<QUaDataType     >>())
 
 #ifdef UA_GENERATED_NAMESPACE_ZERO_FULL
+#define QMetaType_Image              static_cast<QMetaType::Type>(qMetaTypeId<QByteArray             >())
 #define QMetaType_OptionSet          static_cast<QMetaType::Type>(qMetaTypeId<QUaOptionSet           >())
 #define QMetaType_List_OptionSet     static_cast<QMetaType::Type>(qMetaTypeId<QList<QUaOptionSet>    >())
 #endif // UA_GENERATED_NAMESPACE_ZERO_FULL

--- a/src/wrapper/quatypesconverter.cpp
+++ b/src/wrapper/quatypesconverter.cpp
@@ -309,10 +309,9 @@ UA_Variant uaVariantFromQVariant(const QVariant & var
 			return uaVariantFromQVariantScalar<UA_QualifiedName, QUaQualifiedName>(var, uaType);
 		if (qtType == QMetaType_LocalizedText)   // 21 : UA_LocalizedText : { UA_String locale; UA_String text; }
 			return uaVariantFromQVariantScalar<UA_LocalizedText, QUaLocalizedText>(var, uaType);
-		// TODO : image
-		//if (qtType == QMetaType_Image)
-		//	return uaVariantFromQVariantScalar<UA_ByteString, QByteArray>(var, uaType);
 #ifdef UA_GENERATED_NAMESPACE_ZERO_FULL
+		if (qtType == QMetaType_Image)
+			return uaVariantFromQVariantScalar<UA_ByteString, QByteArray>(var, uaType);
 #ifndef OPEN62541_ISSUE3934_RESOLVED
 		if (qtType == QMetaType_OptionSet)       // 108 : UA_OptionSet { UA_ByteString value; UA_ByteString validBits; }
 			return uaVariantFromQVariantScalar<UA_OptionSet, QUaOptionSet>(var, optDataType);
@@ -508,10 +507,9 @@ UA_Variant uaVariantFromQVariantArray(const QVariant & var)
 				return uaVariantFromQVariantArray<UA_QualifiedName, QUaQualifiedName>(var, uaType);
 			if (qtType == QMetaType_LocalizedText)   // 21 : UA_LocalizedText : { UA_String locale; UA_String text; }
 				return uaVariantFromQVariantArray<UA_LocalizedText, QUaLocalizedText>(var, uaType);
-			// TODO : image
-			//if (qtType == QMetaType_Image)
-			//	return uaVariantFromQVariantArray<UA_ByteString, QByteArray>(var, uaType);
 #ifdef UA_GENERATED_NAMESPACE_ZERO_FULL
+			if (qtType == QMetaType_Image)
+				return uaVariantFromQVariantArray<UA_ByteString, QByteArray>(var, uaType);
 			if (qtType == QMetaType_OptionSet)        // 108 : UA_OptionSet { UA_ByteString value; UA_ByteString validBits; }
 				return uaVariantFromQVariantArray<UA_OptionSet, QUaOptionSet>(var, uaType);
 #endif // UA_GENERATED_NAMESPACE_ZERO_FULL
@@ -671,8 +669,9 @@ QVariant uaVariantToQVariant(const UA_Variant & uaVariant, const ArrayType& arrT
 			return uaVariantToQVariantScalar<QUaQualifiedName, UA_QualifiedName>(uaVariant, QMetaType_QualifiedName);
 		if(index == UA_TYPES_LOCALIZEDTEXT)
 			return uaVariantToQVariantScalar<QUaLocalizedText, UA_LocalizedText   >(uaVariant, QMetaType_LocalizedText);
-		// TODO : image
 #ifdef UA_GENERATED_NAMESPACE_ZERO_FULL
+		if (index == UA_TYPES_IMAGEPNG)
+			return uaVariantToQVariantScalar<QByteArray, UA_ImagePNG>(uaVariant, QMetaType_Image);
 		if (index == UA_TYPES_OPTIONSET)
 			return uaVariantToQVariantScalar<QUaOptionSet, UA_OptionSet>(uaVariant, QMetaType_OptionSet);
 #endif // UA_GENERATED_NAMESPACE_ZERO_FULL
@@ -753,10 +752,9 @@ QVariant uaVariantToQVariantList(const UA_Variant & uaVariant)
 			return uaVariantToQVariantArray<QList<QUaQualifiedName>, UA_QualifiedName>(uaVariant, QMetaType_QualifiedName);
 		if (index == UA_TYPES_LOCALIZEDTEXT)
 			return uaVariantToQVariantArray<QList<QUaLocalizedText>, UA_LocalizedText>(uaVariant, QMetaType_LocalizedText);
-		// TODO : image
-		//if (index == UA_TYPES_IMAGEPNG)
-		//	return uaVariantToQVariantArray<QList<QUa>, UA_>(uaVariant, QMetaType_);
 #ifdef UA_GENERATED_NAMESPACE_ZERO_FULL
+		if (index == UA_TYPES_IMAGEPNG)
+			return uaVariantToQVariantArray<QList<QByteArray>, UA_ImagePNG>(uaVariant, QMetaType_Image);
 		if (index == UA_TYPES_OPTIONSET)
 			return uaVariantToQVariantArray<QList<QUaOptionSet>, UA_OptionSet>(uaVariant, QMetaType_OptionSet);
 #endif // UA_GENERATED_NAMESPACE_ZERO_FULL
@@ -823,10 +821,9 @@ QVariant uaVariantToQVariantVector(const UA_Variant & uaVariant)
 			return uaVariantToQVariantArray<QVector<QUaQualifiedName>, UA_QualifiedName>(uaVariant, QMetaType_QualifiedName);
 		if (index == UA_TYPES_LOCALIZEDTEXT)
 			return uaVariantToQVariantArray<QVector<QUaLocalizedText>, UA_LocalizedText>(uaVariant, QMetaType_LocalizedText);
-		// TODO : image
-		//if (index == UA_TYPES_IMAGEPNG)
-		//	return uaVariantToQVariantArray<QVector<QUa>, UA_>(uaVariant, QMetaType_);
 #ifdef UA_GENERATED_NAMESPACE_ZERO_FULL
+		if (index == UA_TYPES_IMAGEPNG)
+			return uaVariantToQVariantArray<QVector<QByteArray>, UA_ImagePNG>(uaVariant, QMetaType_Image);
 		if (index == UA_TYPES_OPTIONSET)
 			return uaVariantToQVariantArray<QVector<QUaOptionSet>, UA_OptionSet>(uaVariant, QMetaType_OptionSet);
 #endif // UA_GENERATED_NAMESPACE_ZERO_FULL


### PR DESCRIPTION
Image type (as viewable with UaExpert) is really just a QByteArray containing PNG data. I moved the image definition under `UA_GENERATED_NAMESPACE_ZERO_FULL`, as that is where the UA type is defined.

The node must be prepared like this to be viewable in UaExpert:
```c++
uaNode->setDataType(QMetaType_Image);
uaNode->setValueRank(UA_VALUERANK_SCALAR);
```

![image](https://user-images.githubusercontent.com/1029876/113875208-cf23bd00-97b6-11eb-8416-6d98bacdb737.png)

**TODO**: in two places, there is `QString("QImage")` for lack of anything better, that could be `QByteArray` perhaps, I am not sure how unique those entries must be.
