### PR TITLE
Fix logMessage in Qt6.

### DIFF
--- a/src/wrapper/quacustomdatatypes.cpp
+++ b/src/wrapper/quacustomdatatypes.cpp
@@ -1308,15 +1308,21 @@ QMetaEnum QUaLog::m_metaEnumLevel = QMetaEnum::fromType<QUa::LogLevel>();
 QUaLog::QUaLog()
 {
 	// default constructor required by Qt
-	message = QByteArray();
 	timestamp = QDateTime::currentDateTimeUtc();
 }
 
 QUaLog::QUaLog(const QString& strMessage,
 	const QUaLogLevel& logLevel,
 	const QUaLogCategory& logCategory)
+	: QUaLog(strMessage.toUtf8(), logLevel, logCategory)
 {
-	message = strMessage.toUtf8();
+}
+
+QUaLog::QUaLog(const QByteArray& baMessage,
+	const QUaLogLevel& logLevel,
+	const QUaLogCategory& logCategory)
+{
+	message = baMessage;
 	level = logLevel;
 	category = logCategory;
 	timestamp = QDateTime::currentDateTimeUtc();

--- a/src/wrapper/quacustomdatatypes.h
+++ b/src/wrapper/quacustomdatatypes.h
@@ -176,6 +176,7 @@ struct QUaLog
     QUaLog();
     // consutructor accepting QString instead of QByteArray (to support generating messages with QObject::tr)
     QUaLog(const QString& strMessage, const QUaLogLevel& logLevel, const QUaLogCategory& logCategory);
+    QUaLog(const QByteArray& baMessage, const QUaLogLevel& logLevel, const QUaLogCategory& logCategory);
     // members
     QByteArray     message;
     QUaLogLevel    level;

--- a/src/wrapper/quaserver.cpp
+++ b/src/wrapper/quaserver.cpp
@@ -39,8 +39,6 @@
 #include <QMetaProperty>
 #include <QTimer>
 
-#define QUA_MAX_LOG_MESSAGE_SIZE 1024
-
 /* helper null log for avoiding startup messages */
 void UA_Log_Discard_log(void *context,
                         UA_LogLevel level,
@@ -1011,7 +1009,6 @@ QUaServer::QUaServer(QObject* parent/* = 0*/)
 	m_bytePrivateKey = QByteArray();
 	m_bytePrivateKeyInternal = QByteArray();
 #endif
-	m_logBuffer.resize(QUA_MAX_LOG_MESSAGE_SIZE);
 #ifdef UA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS
 	m_conditionsRefreshRequired = false;
 #endif // UA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS
@@ -1475,10 +1472,9 @@ UA_Logger QUaServer::getLogger()
 			{
 				return;
 			}
-			vsprintf(srv->m_logBuffer.data(), msg, args);
-			// NOTE : do not convert QBytearray to QString to avoid overhead
+			vsprintf(srv->m_logBuffer, msg, args);
 			emit srv->logMessage({
-				QString::fromUtf8( srv->m_logBuffer.data() ),
+				QByteArray( srv->m_logBuffer ),
 				static_cast<QUaLogLevel>(level),
 				static_cast<QUaLogCategory>(category)
 			});

--- a/src/wrapper/quaserver.cpp
+++ b/src/wrapper/quaserver.cpp
@@ -1478,7 +1478,7 @@ UA_Logger QUaServer::getLogger()
 			vsprintf(srv->m_logBuffer.data(), msg, args);
 			// NOTE : do not convert QBytearray to QString to avoid overhead
 			emit srv->logMessage({
-				srv->m_logBuffer,
+				QString::fromUtf8( srv->m_logBuffer.data() ),
 				static_cast<QUaLogLevel>(level),
 				static_cast<QUaLogCategory>(category)
 			});

--- a/src/wrapper/quaserver.h
+++ b/src/wrapper/quaserver.h
@@ -27,6 +27,8 @@ class QUaRefreshRequiredEvent;
 #include <QUaHistoryBackend>
 #endif // UA_ENABLE_HISTORIZING
 
+#define QUA_MAX_LOG_MESSAGE_SIZE 1024
+
 typedef std::function<QUaNodeId(const QUaNodeId&, const QUaQualifiedName&)> QUaChildNodeIdCallback;
 
 class QUaServer : public QObject
@@ -299,7 +301,7 @@ private:
 	QByteArray              m_byteCertificateInternal; // NOTE : needs to exists as long as server instance
 	bool                    m_anonymousLoginAllowed;
 	QUaFolderObject       * m_pobjectsFolder;
-	QByteArray              m_logBuffer;
+	char                    m_logBuffer[QUA_MAX_LOG_MESSAGE_SIZE];
     bool                    m_beingDestroyed;
 
 #ifdef UA_ENABLE_ENCRYPTION


### PR DESCRIPTION
In Qt6, all 1024 characters from srv->m_logBuffer are logged, even though the output should be limited to character code 0. This fix solves this problem.