### PR TITLE
Replace deprecated functions.

### DIFF
--- a/src/wrapper/quaenum.h
+++ b/src/wrapper/quaenum.h
@@ -1,6 +1,8 @@
 #ifndef QUAENUM_H
 #define QUAENUM_H
 
+#include <QUaCustomDataTypes>
+
 typedef qint64 QUaEnumKey;
 struct QUaEnumEntry
 {


### PR DESCRIPTION
Deprecated functions can be noticed if you add the lines to the .pro file: 
equals(QT_MAJOR_VERSION, 5): DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x051500 
equals(QT_MAJOR_VERSION, 6): DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060500