### PR TITLE
Replace QStringRef with QStringView.

### DIFF
--- a/src/wrapper/quacustomdatatypes.h
+++ b/src/wrapper/quacustomdatatypes.h
@@ -226,13 +226,13 @@ inline QString QUaLog::toString(
         )
 {
     QString strTime  = log.timestamp.toLocalTime().toString(timeFormat);
-    QString strLevel = QUaLog::m_metaEnumLevel.valueToKey(static_cast<int>(log.level));
-    QString strCateg = QUaLog::m_metaEnumCategory.valueToKey(static_cast<int>(log.category));
+    QString strLevel = QString::fromLatin1( QUaLog::m_metaEnumLevel.valueToKey(static_cast<int>(log.level)) );
+    QString strCateg = QString::fromLatin1( QUaLog::m_metaEnumCategory.valueToKey(static_cast<int>(log.category)) );
     return lineFormat
             .arg(strTime)
             .arg(strLevel)
             .arg(strCateg)
-            .arg(QString(log.message))
+            .arg(QString::fromUtf8(log.message))
             .arg(separator);
 }
 
@@ -597,7 +597,6 @@ public:
     void operator= (const UA_LocalizedText& uaLocalizedText);
     void operator= (const QString& strXmlLocalizedText);
     void operator= (const char* strXmlLocalizedText);
-    void operator= (const QUaLocalizedText& other);
     bool operator==(const QUaLocalizedText& other) const;
     bool operator< (const QUaLocalizedText& other) const;
 

--- a/src/wrapper/quaserver.pri
+++ b/src/wrapper/quaserver.pri
@@ -3,7 +3,6 @@ include($$PWD/../amalgamation/open62541.pri)
 QT     += core
 CONFIG += c++11
 CONFIG -= flat
-greaterThan(QT_MAJOR_VERSION, 5): QT += core5compat
 
 INCLUDEPATH += $$PWD/
 


### PR DESCRIPTION
Changes:
- Replace QStringRef with QStringView to get rid of the core5compat dependency.
- Replace implicit conversions to QString with explicit ones so they are visible.
- Removed one function, which is already implicitly declared. It causes a lot of compiler warnings.