### PR TITLE
Replace implicit conversions to QString.

### DIFF
--- a/src/wrapper/quabasevariable.cpp
+++ b/src/wrapper/quabasevariable.cpp
@@ -748,11 +748,13 @@ void QUaBaseVariable::setDataTypeEnum(const QMetaEnum & metaEnum)
 	Q_CHECK_PTR(m_qUaServer);
 	Q_ASSERT(!UA_NodeId_isNull(&m_nodeId));
 	// compose enum name
-	#if QT_VERSION >= 0x051200
-		QString strEnumName = QStringLiteral("%1::%2").arg(metaEnum.scope()).arg(metaEnum.enumName());
-	#else
-		QString strEnumName = QStringLiteral("%1::%2").arg(metaEnum.scope()).arg(metaEnum.name());
-	#endif
+    QString strEnumName = QStringLiteral("%1::%2").arg(
+				QString::fromLatin1(metaEnum.scope()),
+#if (QT_VERSION >= QT_VERSION_CHECK(5,12,0))
+				QString::fromLatin1(metaEnum.enumName()));
+#else
+				QString::fromLatin1(metaEnum.name()));
+#endif
 	// register if not exists
 	if (!m_qUaServer->m_hashEnums.contains(strEnumName))
 	{

--- a/src/wrapper/quabasevariable.h
+++ b/src/wrapper/quabasevariable.h
@@ -101,7 +101,7 @@ public:
 	)
 	{
 		this->setValue(
-			QString(value),
+			QString::fromUtf8(value),
 			statusCode,
 			sourceTimestamp,
 			serverTimestamp,

--- a/src/wrapper/quaenum.cpp
+++ b/src/wrapper/quaenum.cpp
@@ -196,10 +196,12 @@ void QUaServer::removeEnumEntry(const QString& strEnumName, const QUaEnumKey& en
 void QUaServer::registerEnum(const QMetaEnum& metaEnum, const QUaNodeId& nodeId/* = ""*/)
 {
 	// compose enum name
-#if QT_VERSION >= 0x051200
-	QString strBrowseName = QStringLiteral("%1::%2").arg(metaEnum.scope()).arg(metaEnum.enumName());
+	QString strBrowseName = QStringLiteral("%1::%2").arg(
+				QString::fromLatin1(metaEnum.scope()),
+#if (QT_VERSION >= QT_VERSION_CHECK(5,12,0))
+				QString::fromLatin1(metaEnum.enumName()));
 #else
-	QString strBrowseName = QStringLiteral("%1::%2").arg(metaEnum.scope()).arg(metaEnum.name());
+				QString::fromLatin1(metaEnum.name()));
 #endif
 	// compose values
 	QUaEnumMap mapEnum;

--- a/src/wrapper/quaserver.cpp
+++ b/src/wrapper/quaserver.cpp
@@ -429,7 +429,7 @@ UA_StatusCode QUaServer::callMetaMethod(
 	{
 		QVariant varArg;
 		auto metaType    = (QMetaType::Type)metaMethod.parameterType(k);
-		auto strTypeName = QString(listTypeNames.at(k));
+		auto strTypeName = QString::fromUtf8(listTypeNames.at(k));
 		// NOTE : enums are QMetaType::UnknownType
 		Q_ASSERT_X(metaType != QMetaType::UnknownType ||
 			server->m_hashEnums.contains(strTypeName),
@@ -466,7 +466,7 @@ UA_StatusCode QUaServer::callMetaMethod(
 	int retType = metaMethod.returnType();
 	// NOTE : enums are QMetaType::UnknownType
 	Q_ASSERT_X(retType != QMetaType::UnknownType ||
-		server->m_hashEnums.contains(metaMethod.typeName()),
+		server->m_hashEnums.contains( QString::fromUtf8(metaMethod.typeName()) ),
 		"QUaServer::callMetaMethod",
 		"Return type is not registered. Try using qRegisterMetaType."
 	);
@@ -585,7 +585,7 @@ QHash<QUaQualifiedName, int> QUaServer::metaMethodIndexes(const QMetaObject& met
 			continue;
 		}
 		// add method
-		QUaQualifiedName methName = QString(metaMethod.name());
+		QUaQualifiedName methName = QString::fromUtf8(metaMethod.name());
 		retHash[methName] = methIdx;
 	}
 	return retHash;
@@ -796,7 +796,7 @@ void QUaServer::newSession(QUaServer* server,
 		remote_name, sizeof(remote_name),
 		NULL, 0, NI_NUMERICHOST);
     Q_UNUSED(res);
-	strAddress = QString(remote_name);
+	strAddress = QString::fromUtf8(remote_name);
 	// get peer port
 	switch (address.sa_family) 
 	{
@@ -1533,7 +1533,7 @@ void QUaServer::setPrivateKey(const QByteArray& bytePrivateKey)
 
 QString QUaServer::applicationName() const
 {
-	return QString(m_byteApplicationName);
+	return QString::fromUtf8(m_byteApplicationName);
 }
 
 void QUaServer::setApplicationName(const QString& strApplicationName)
@@ -1546,7 +1546,7 @@ void QUaServer::setApplicationName(const QString& strApplicationName)
 
 QString QUaServer::applicationUri() const
 {
-	return QString(m_byteApplicationUri);
+	return QString::fromUtf8(m_byteApplicationUri);
 }
 
 void QUaServer::setApplicationUri(const QString& strApplicationUri)
@@ -1559,7 +1559,7 @@ void QUaServer::setApplicationUri(const QString& strApplicationUri)
 
 QString QUaServer::productName() const
 {
-	return QString(m_byteProductName);
+	return QString::fromUtf8(m_byteProductName);
 }
 
 void QUaServer::setProductName(const QString& strProductName)
@@ -1572,7 +1572,7 @@ void QUaServer::setProductName(const QString& strProductName)
 
 QString QUaServer::productUri() const
 {
-	return QString(m_byteProductUri);
+	return QString::fromUtf8(m_byteProductUri);
 }
 
 void QUaServer::setProductUri(const QString& strProductUri)
@@ -1585,7 +1585,7 @@ void QUaServer::setProductUri(const QString& strProductUri)
 
 QString QUaServer::manufacturerName() const
 {
-	return QString(m_byteManufacturerName);
+	return QString::fromUtf8(m_byteManufacturerName);
 }
 
 void QUaServer::setManufacturerName(const QString& strManufacturerName)
@@ -1598,7 +1598,7 @@ void QUaServer::setManufacturerName(const QString& strManufacturerName)
 
 QString QUaServer::softwareVersion() const
 {
-	return QString(m_byteSoftwareVersion);
+	return QString::fromUtf8(m_byteSoftwareVersion);
 }
 
 void QUaServer::setSoftwareVersion(const QString& strSoftwareVersion)
@@ -1611,7 +1611,7 @@ void QUaServer::setSoftwareVersion(const QString& strSoftwareVersion)
 
 QString QUaServer::buildNumber() const
 {
-	return QString(m_byteBuildNumber);
+	return QString::fromUtf8(m_byteBuildNumber);
 }
 
 void QUaServer::setBuildNumber(const QString& strBuildNumber)
@@ -1755,7 +1755,7 @@ void QUaServer::registerTypeInternal(
 		return;
 	}
 	// check if already registered
-	QString   strClassName = QString(metaObject.className());
+	QString   strClassName = QString::fromUtf8(metaObject.className());
 	UA_NodeId newTypeNodeId = m_mapTypes.value(strClassName, UA_NODEID_NULL);
 	if (!UA_NodeId_isNull(&newTypeNodeId))
 	{
@@ -1767,7 +1767,7 @@ void QUaServer::registerTypeInternal(
 	browseName.namespaceIndex = 0;
 	browseName.name = QUaTypesConverter::uaStringFromQString(strClassName);
 	// check if base class is registered
-	QString strBaseClassName = QString(metaObject.superClass()->className());
+	QString strBaseClassName = QString::fromUtf8(metaObject.superClass()->className());
 	if (!m_mapTypes.contains(strBaseClassName))
 	{
 		// recursive
@@ -2011,7 +2011,7 @@ void QUaServer::registerTypeDefaults(const UA_NodeId& typeNodeId, const QMetaObj
 			"Qt type does not implement method. Qt types must implement both mandatory and optional.");
 		if (!hashQtMethods.contains(methBrowseName))
 		{
-			QString strClassName = QString(metaObject.className());
+			QString strClassName = QString::fromUtf8(metaObject.className());
 			qDebug() << "Error Registering" << methBrowseName << "for" << strClassName;
 			continue;
 		}
@@ -2055,10 +2055,12 @@ void QUaServer::addMetaProperties(const QMetaObject& metaObject)
 		{
 			QMetaEnum metaEnum = metaProperty.enumerator();
 			// compose enum name
-#if QT_VERSION >= 0x051200
-			QString strEnumName = QStringLiteral("%1::%2").arg(metaEnum.scope()).arg(metaEnum.enumName());
+			QString strEnumName = QStringLiteral("%1::%2").arg(
+						QString::fromLatin1(metaEnum.scope()),
+#if (QT_VERSION >= QT_VERSION_CHECK(5,12,0))
+						QString::fromLatin1(metaEnum.enumName()));
 #else
-			QString strEnumName = QStringLiteral("%1::%2").arg(metaEnum.scope()).arg(metaEnum.name());
+						QString::fromLatin1(metaEnum.name()));
 #endif
 			// must already be registered by now
 			Q_ASSERT(m_hashEnums.contains(strEnumName));
@@ -2212,7 +2214,7 @@ void QUaServer::addMetaMethods(const QMetaObject& parentMetaObject)
 		// validate return type
 		auto returnType = (QMetaType::Type)metaMethod.returnType();
 		bool isSupported = QUaTypesConverter::isSupportedQType(returnType);
-		bool isEnumType = this->m_hashEnums.contains(metaMethod.typeName());
+		bool isEnumType = this->m_hashEnums.contains( QString::fromUtf8(metaMethod.typeName()) );
 		bool isArrayType = QUaTypesConverter::isQTypeArray(returnType);
 		bool isValidType = isSupported || isEnumType || isArrayType;
 		// NOTE : enums are QMetaType::UnknownType
@@ -2238,7 +2240,7 @@ void QUaServer::addMetaMethods(const QMetaObject& parentMetaObject)
 				(char*)"Result Value");
 			outputArgumentInstance.name = QUaTypesConverter::uaStringFromQString( QStringLiteral("Result") );
 			outputArgumentInstance.dataType = isEnumType ?
-				this->m_hashEnums.value(QString(metaMethod.typeName())) :
+				this->m_hashEnums.value(QString::fromUtf8(metaMethod.typeName())) :
 				QUaTypesConverter::uaTypeNodeIdFromQType(returnType);
 			outputArgumentInstance.valueRank = isArrayType ?
 				UA_VALUERANK_ONE_DIMENSION :
@@ -2261,7 +2263,7 @@ void QUaServer::addMetaMethods(const QMetaObject& parentMetaObject)
 		{
 			auto argType = (QMetaType::Type)metaMethod.parameterType(k);
 			isSupported = QUaTypesConverter::isSupportedQType(argType);
-			isEnumType  = this->m_hashEnums.contains(listTypeNames[k]);
+			isEnumType  = this->m_hashEnums.contains( QString::fromUtf8(listTypeNames[k]) );
 			isArrayType = QUaTypesConverter::isQTypeArray(argType);
 			isValidType = isSupported || isEnumType || isArrayType;
 			// NOTE : enums are QMetaType::UnknownType
@@ -2282,11 +2284,11 @@ void QUaServer::addMetaMethods(const QMetaObject& parentMetaObject)
 			UA_Argument_init(&inputArgument);
 			// check if type is registered enum
 			UA_NodeId uaType = isEnumType ?
-				this->m_hashEnums.value(listTypeNames[k]) :
+				this->m_hashEnums.value( QString::fromUtf8(listTypeNames[k]) ) :
 				QUaTypesConverter::uaTypeNodeIdFromQType(argType);
 			// create n-th argument
 			inputArgument.description = UA_LOCALIZEDTEXT((char*)"", (char*)"Method Argument");
-			inputArgument.name = QUaTypesConverter::uaStringFromQString(listArgNames[k]);
+			inputArgument.name = QUaTypesConverter::uaStringFromQString( QString::fromUtf8(listArgNames[k]) );
 			inputArgument.dataType = uaType;
 			inputArgument.valueRank = UA_VALUERANK_SCALAR;
 			if (isArrayType)
@@ -2374,7 +2376,7 @@ void QUaServer::addMetaMethods(const QMetaObject& parentMetaObject)
 // NOTE : do not clean
 UA_NodeId QUaServer::typeIdByMetaObject(const QMetaObject& metaObject)
 {
-	QString   strClassName = QString(metaObject.className());
+	QString   strClassName = QString::fromUtf8(metaObject.className());
 	UA_NodeId typeNodeId   = m_mapTypes.value(strClassName, UA_NODEID_NULL);
 	if (UA_NodeId_isNull(&typeNodeId))
 	{

--- a/src/wrapper/quaserver.h
+++ b/src/wrapper/quaserver.h
@@ -654,7 +654,7 @@ template<typename T>
 inline void QUaServer::registerSpecificationType(const UA_NodeId& typeNodeId, const bool abstract/* = false*/)
 {
     auto& metaObject = T::staticMetaObject;
-    QString strClassName = QString(metaObject.className());
+    QString strClassName = QString::fromUtf8(metaObject.className());
     m_mapTypes.insert(strClassName, typeNodeId);
     m_hashMetaObjects.insert(strClassName, metaObject);
     // register for default mandatory children and so on
@@ -697,7 +697,7 @@ inline QMetaObject::Connection QUaServer::instanceCreated(
 		return QMetaObject::Connection();
 	}
 	// try to get typeNodeId, if null, then register it
-	QString   strClassName = QString(metaObject.className());
+	QString   strClassName = QString::fromUtf8(metaObject.className());
 	UA_NodeId typeNodeId = m_mapTypes.value(strClassName, UA_NODEID_NULL);
 	if (UA_NodeId_isNull(&typeNodeId))
 	{
@@ -1440,11 +1440,13 @@ struct QUaMethodTraitsBase
     {
         QMetaEnum metaEnum = QMetaEnum::fromType<T>();
         // compose enum name
-        #if QT_VERSION >= 0x051200
-            QString strEnumName = QStringLiteral("%1::%2").arg(metaEnum.scope()).arg(metaEnum.enumName());
-        #else
-            QString strEnumName = QStringLiteral("%1::%2").arg(metaEnum.scope()).arg(metaEnum.name());
-        #endif
+            QString strEnumName = QStringLiteral("%1::%2").arg(
+                        QString::fromLatin1(metaEnum.scope()),
+#if (QT_VERSION >= QT_VERSION_CHECK(5,12,0))
+                        QString::fromLatin1(metaEnum.enumName()));
+#else
+                        QString::fromLatin1(metaEnum.name()));
+#endif
         // register if not exists
         if (!uaServer->m_hashEnums.contains(strEnumName))
         {

--- a/src/wrapper/quatypesconverter.cpp
+++ b/src/wrapper/quatypesconverter.cpp
@@ -98,7 +98,7 @@ QString nodeIdToQString(const UA_NodeId & id)
     case UA_NODEIDTYPE_BYTESTRING:
         {
 		const QByteArray temp(reinterpret_cast<char *>(id.identifier.byteString.data), static_cast<int>(id.identifier.byteString.length));
-		result.append(QStringLiteral("b=")).append(temp.toBase64());
+		result.append(QStringLiteral("b=")).append( QString::fromLatin1(temp.toBase64()) );
 		break;
         }
     }
@@ -108,16 +108,15 @@ QString nodeIdToQString(const UA_NodeId & id)
 bool nodeIdStringSplit(const QString & nodeIdString, quint16 * nsIndex, QString * identifier, char * identifierType)
 {
 	quint16 namespaceIndex = 0;
-	QStringList components = nodeIdString.split(QLatin1String(";"));
+	auto components = QStringView(nodeIdString).split(QLatin1Char(';'));
 	if (components.size() > 2)
 	{
 		return false;
 	}
-	if (components.size() == 2 && components.at(0).contains(QLatin1String("ns=")))
+	if (components.size() == 2 && components.at(0).startsWith(QLatin1String("ns=")))
 	{
-		QString strNs = components.at(0).split(QLatin1String("ns=")).last();
 		bool success = false;
-		uint ns = strNs.toUInt(&success);
+		uint ns = components.at(0).mid(3).toUInt(&success);
 		if (!success || ns > (std::numeric_limits<quint16>::max)())
 			return false;
 		namespaceIndex = ns;
@@ -130,7 +129,7 @@ bool nodeIdStringSplit(const QString & nodeIdString, quint16 * nsIndex, QString 
 	{
 		return false;
 	}
-	auto lastParts = strLast.split(QLatin1String("="));
+	auto lastParts = strLast.toString().split(QLatin1Char('='));
 	if (nsIndex)
 	{
 		*nsIndex = namespaceIndex;
@@ -146,7 +145,7 @@ bool nodeIdStringSplit(const QString & nodeIdString, quint16 * nsIndex, QString 
 			QString() : // NOTE : possible that just "i="
 			lastParts.size() == 2 ?
 			lastParts.last() : 
-			lastParts.mid(1).join(QLatin1String("="));
+			lastParts.mid(1).join(QLatin1Char('='));
 	}
 	return true;
 }
@@ -156,7 +155,7 @@ QString nodeClassToQString(const UA_NodeClass & nclass)
 	switch (nclass)
 	{
 	case UA_NODECLASS_UNSPECIFIED:
-		return QStringLiteral();
+		return QString();
 	case UA_NODECLASS_OBJECT:
 		return QStringLiteral("OBJECT");
 	case UA_NODECLASS_VARIABLE:
@@ -176,7 +175,7 @@ QString nodeClassToQString(const UA_NodeClass & nclass)
 	default:
 		break;
 	}
-	return QStringLiteral();
+	return QString();
 }
 
 QString uaStringToQString(const UA_String & string)


### PR DESCRIPTION
Replace implicit conversions to QString with explicit ones so they are visible. 
Implicit conversions can be seen if you add the following lines to the .pro file: 
DEFINES += QT_NO_CAST_FROM_ASCII
DEFINES += QT_NO_CAST_TO_ASCII