### PR TITLE
Refactoring QUaBaseVariable::setValue

### DIFF
--- a/src/wrapper/quaserver.cpp
+++ b/src/wrapper/quaserver.cpp
@@ -479,7 +479,7 @@ UA_StatusCode QUaServer::callMetaMethod(
 	if (retType != QMetaType::Void)
 	{
 #if (QT_VERSION < QT_VERSION_CHECK(6,0,0))
-		returnValue = QVariant(retType);
+		returnValue = QVariant( static_cast<QVariant::Type>(retType) );
 #else
 		returnValue = QVariant( QMetaType(retType) );
 #endif

--- a/src/wrapper/quatypesconverter.h
+++ b/src/wrapper/quatypesconverter.h
@@ -18,9 +18,15 @@ namespace QUaTypesConverter {
 	UA_String uaStringFromQString(const QString &uaString);
 
 	// qt supported
-	bool            isQTypeArray    (const QMetaType::Type &type);
-	QMetaType::Type getQArrayType   (const QMetaType::Type &type);
+	bool            isQTypeArray (const QMetaType::Type &type);
+	bool            isQTypeArray (const QMetaType &metaType);
+	bool            isQTypeArray (const QByteArray &typeName);
+	QMetaType::Type getQArrayType(const QMetaType::Type &type);
+	QMetaType::Type getQArrayType(const QMetaType &metaType);
+	QMetaType::Type getQArrayType(const QByteArray &typeName);
 	bool            isSupportedQType(const QMetaType::Type &type);
+	bool            canConvertQVariantList(const QVariant &value);
+
 	// ua from c++
 	template<typename T>
 	UA_NodeId uaTypeNodeIdFromCpp();


### PR DESCRIPTION
Refactoring QUaBaseVariable::setValue and some related functions.
This is a more complete fix for the problem: https://github.com/QUaServer/QUaServer/issues/40
It is now acceptable for the array to be empty.