### PR TITLE
Add support for open62541 version 1.3

### DIFF
--- a/src/wrapper/quaacknowledgeablecondition.cpp
+++ b/src/wrapper/quaacknowledgeablecondition.cpp
@@ -360,10 +360,10 @@ void QUaAcknowledgeableCondition::Confirm(QByteArray EventId, QUaLocalizedText C
 	this->setConfirmed(true);
 }
 
-QUaLocalizedText QUaAcknowledgeableCondition::m_ackedStateTrueState      = {0, QObject::tr("Acknowledged")};
-QUaLocalizedText QUaAcknowledgeableCondition::m_ackedStateFalseState     = {0, QObject::tr("Unacknowledged")};
-QUaLocalizedText QUaAcknowledgeableCondition::m_confirmedStateTrueState  = {0, QObject::tr("Confirmed")};
-QUaLocalizedText QUaAcknowledgeableCondition::m_confirmedStateFalseState = {0, QObject::tr("Unconfirmed")};
+QUaLocalizedText QUaAcknowledgeableCondition::m_ackedStateTrueState      = {0, QT_TR_NOOP("Acknowledged")};
+QUaLocalizedText QUaAcknowledgeableCondition::m_ackedStateFalseState     = {0, QT_TR_NOOP("Unacknowledged")};
+QUaLocalizedText QUaAcknowledgeableCondition::m_confirmedStateTrueState  = {0, QT_TR_NOOP("Confirmed")};
+QUaLocalizedText QUaAcknowledgeableCondition::m_confirmedStateFalseState = {0, QT_TR_NOOP("Unconfirmed")};
 
 void QUaAcknowledgeableCondition::resetInternals()
 {
@@ -456,16 +456,16 @@ QUaTwoStateVariable* QUaAcknowledgeableCondition::getConfirmedState()
 /****************************************************************************************
 */
 
-QUaBrowsePath QUaAcknowledgeableConditionBranch::AckedState               ({ { 0, "AckedState" } }); // [LocalizedText]
-QUaBrowsePath QUaAcknowledgeableConditionBranch::AckedState_Id            ({ { 0, "AckedState" },{ 0, "Id"             } }); // [Boolean]
-//QUaBrowsePath QUaAcknowledgeableConditionBranch::AckedState_FalseState    ({ { 0, "AckedState" },{ 0, "FalseState"     } }); // [LocalizedText]
-//QUaBrowsePath QUaAcknowledgeableConditionBranch::AckedState_TrueState     ({ { 0, "AckedState" },{ 0, "TrueState"      } }); // [LocalizedText]
-QUaBrowsePath QUaAcknowledgeableConditionBranch::AckedState_TransitionTime({ { 0, "AckedState" },{ 0, "TransitionTime" } }); // [UtcTime]
-QUaBrowsePath QUaAcknowledgeableConditionBranch::ConfirmedState               ({ { 0, "ConfirmedState" } }); // [LocalizedText]
-QUaBrowsePath QUaAcknowledgeableConditionBranch::ConfirmedState_Id            ({ { 0, "ConfirmedState" },{ 0, "Id"             } }); // [Boolean]
-//QUaBrowsePath QUaAcknowledgeableConditionBranch::ConfirmedState_FalseState    ({ { 0, "ConfirmedState" },{ 0, "FalseState"     } }); // [LocalizedText]
-//QUaBrowsePath QUaAcknowledgeableConditionBranch::ConfirmedState_TrueState     ({ { 0, "ConfirmedState" },{ 0, "TrueState"      } }); // [LocalizedText]
-QUaBrowsePath QUaAcknowledgeableConditionBranch::ConfirmedState_TransitionTime({ { 0, "ConfirmedState" },{ 0, "TransitionTime" } }); // [UtcTime]
+QUaBrowsePath QUaAcknowledgeableConditionBranch::AckedState               ({ { 0, QStringLiteral("AckedState") } }); // [LocalizedText]
+QUaBrowsePath QUaAcknowledgeableConditionBranch::AckedState_Id            ({ { 0, QStringLiteral("AckedState") },{ 0, QStringLiteral("Id")             } }); // [Boolean]
+//QUaBrowsePath QUaAcknowledgeableConditionBranch::AckedState_FalseState    ({ { 0, QStringLiteral("AckedState") },{ 0, QStringLiteral("FalseState")     } }); // [LocalizedText]
+//QUaBrowsePath QUaAcknowledgeableConditionBranch::AckedState_TrueState     ({ { 0, QStringLiteral("AckedState") },{ 0, QStringLiteral("TrueState")      } }); // [LocalizedText]
+QUaBrowsePath QUaAcknowledgeableConditionBranch::AckedState_TransitionTime({ { 0, QStringLiteral("AckedState") },{ 0, QStringLiteral("TransitionTime") } }); // [UtcTime]
+QUaBrowsePath QUaAcknowledgeableConditionBranch::ConfirmedState               ({ { 0, QStringLiteral("ConfirmedState") } }); // [LocalizedText]
+QUaBrowsePath QUaAcknowledgeableConditionBranch::ConfirmedState_Id            ({ { 0, QStringLiteral("ConfirmedState") },{ 0, QStringLiteral("Id")             } }); // [Boolean]
+//QUaBrowsePath QUaAcknowledgeableConditionBranch::ConfirmedState_FalseState    ({ { 0, QStringLiteral("ConfirmedState") },{ 0, QStringLiteral("FalseState")     } }); // [LocalizedText]
+//QUaBrowsePath QUaAcknowledgeableConditionBranch::ConfirmedState_TrueState     ({ { 0, QStringLiteral("ConfirmedState") },{ 0, QStringLiteral("TrueState")      } }); // [LocalizedText]
+QUaBrowsePath QUaAcknowledgeableConditionBranch::ConfirmedState_TransitionTime({ { 0, QStringLiteral("ConfirmedState") },{ 0, QStringLiteral("TransitionTime") } }); // [UtcTime]
 
 QUaAcknowledgeableConditionBranch::QUaAcknowledgeableConditionBranch(
 	QUaCondition* parent,

--- a/src/wrapper/quaalarmcondition.cpp
+++ b/src/wrapper/quaalarmcondition.cpp
@@ -278,11 +278,11 @@ void QUaAlarmCondition::resetInternals()
 /***************************************************************************************
 */
 
-QUaBrowsePath QUaAlarmConditionBranch::ActiveState               ({ { 0, "ActiveState" } }); // [LocalizedText]
-QUaBrowsePath QUaAlarmConditionBranch::ActiveState_Id            ({ { 0, "ActiveState" },{ 0, "Id"             } }); // [Boolean]
-//QUaBrowsePath QUaAlarmConditionBranch::ActiveState_FalseState    ({ { 0, "ActiveState" },{ 0, "FalseState"     } }); // [LocalizedText]
-//QUaBrowsePath QUaAlarmConditionBranch::ActiveState_TrueState     ({ { 0, "ActiveState" },{ 0, "TrueState"      } }); // [LocalizedText]
-QUaBrowsePath QUaAlarmConditionBranch::ActiveState_TransitionTime({ { 0, "ActiveState" },{ 0, "TransitionTime" } }); // [UtcTime]
+QUaBrowsePath QUaAlarmConditionBranch::ActiveState               ({ { 0, QStringLiteral("ActiveState") } }); // [LocalizedText]
+QUaBrowsePath QUaAlarmConditionBranch::ActiveState_Id            ({ { 0, QStringLiteral("ActiveState") },{ 0, QStringLiteral("Id")             } }); // [Boolean]
+//QUaBrowsePath QUaAlarmConditionBranch::ActiveState_FalseState    ({ { 0, QStringLiteral("ActiveState") },{ 0, QStringLiteral("FalseState")     } }); // [LocalizedText]
+//QUaBrowsePath QUaAlarmConditionBranch::ActiveState_TrueState     ({ { 0, QStringLiteral("ActiveState") },{ 0, QStringLiteral("TrueState")      } }); // [LocalizedText]
+QUaBrowsePath QUaAlarmConditionBranch::ActiveState_TransitionTime({ { 0, QStringLiteral("ActiveState") },{ 0, QStringLiteral("TransitionTime") } }); // [UtcTime]
 
 QUaAlarmConditionBranch::QUaAlarmConditionBranch(
 	QUaCondition* parent,

--- a/src/wrapper/quabaseevent.cpp
+++ b/src/wrapper/quabaseevent.cpp
@@ -239,15 +239,6 @@ UA_ByteString QUaBaseEvent::generateEventIdInternal()
 	return ret;
 }
 
-static const UA_NodeId objectsFolderId = { 0, UA_NODEIDTYPE_NUMERIC, {UA_NS0ID_OBJECTSFOLDER} };
-#define EMIT_REFS_ROOT_COUNT 4
-static const UA_NodeId emitReferencesRoots[EMIT_REFS_ROOT_COUNT] ={ 
-    {0, UA_NODEIDTYPE_NUMERIC, {UA_NS0ID_ORGANIZES     }},
-    {0, UA_NODEIDTYPE_NUMERIC, {UA_NS0ID_HASCOMPONENT  }},
-    {0, UA_NODEIDTYPE_NUMERIC, {UA_NS0ID_HASEVENTSOURCE}},
-    {0, UA_NODEIDTYPE_NUMERIC, {UA_NS0ID_HASNOTIFIER   }} 
-};
-
 void QUaBaseEvent::triggerInternal()
 {
     if (!this->shouldTrigger())

--- a/src/wrapper/quacondition.cpp
+++ b/src/wrapper/quacondition.cpp
@@ -84,7 +84,7 @@ void QUaCondition::setSourceNode(const QUaNodeId& sourceNodeId)
 	bool isRetained = this->retain();
 	if (m_sourceNode)
 	{
-		m_sourceNode->removeReference({ "HasCondition" , "IsConditionOf" }, this, true);
+		m_sourceNode->removeReference({ QStringLiteral("HasCondition"), QStringLiteral("IsConditionOf") }, this, true);
 		// remove destroy connections
 		QObject::disconnect(m_sourceDestroyed);
 		QObject::disconnect(m_retainedDestroyed);
@@ -104,7 +104,7 @@ void QUaCondition::setSourceNode(const QUaNodeId& sourceNodeId)
 	if (m_sourceNode)
 	{
 		// NOTE : references are RAM hungry and is not worth having them for branches
-		m_sourceNode->addReference({ "HasCondition" , "IsConditionOf" }, this, true);
+		m_sourceNode->addReference({ QStringLiteral("HasCondition"), QStringLiteral("IsConditionOf") }, this, true);
 		// add destroy connection
 		m_sourceDestroyed = QObject::connect(m_sourceNode, &QObject::destroyed, this,
 		[this]() {
@@ -121,7 +121,7 @@ void QUaCondition::setSourceNode(const QUaNodeId& sourceNodeId)
 				return;
 			}
 			this->setSourceNode(QUaNodeId());
-			this->setSourceName("");
+			this->setSourceName(QString());
 		});
 		// add to hash
 		if (isRetained)
@@ -811,20 +811,20 @@ void QUaCondition::processMonitoredItem(UA_MonitoredItem* monitoredItem, QUaServ
 */
 
 // QUaBaseEvent
-QUaBrowsePath QUaConditionBranch::EventId     ({ { 0, "EventId"      } }); // [ByteString]
-QUaBrowsePath QUaConditionBranch::Message     ({ { 0, "Message"      } }); // [LocalizedText]
-QUaBrowsePath QUaConditionBranch::Time        ({ { 0, "Time"         } }); // [UtcTime]
-QUaBrowsePath QUaConditionBranch::ClientUserId({ { 0, "ClientUserId" } }); // [String]
+QUaBrowsePath QUaConditionBranch::EventId     ({ { 0, QStringLiteral("EventId")      } }); // [ByteString]
+QUaBrowsePath QUaConditionBranch::Message     ({ { 0, QStringLiteral("Message")      } }); // [LocalizedText]
+QUaBrowsePath QUaConditionBranch::Time        ({ { 0, QStringLiteral("Time")         } }); // [UtcTime]
+QUaBrowsePath QUaConditionBranch::ClientUserId({ { 0, QStringLiteral("ClientUserId") } }); // [String]
 // QUaCondition
-QUaBrowsePath QUaConditionBranch::BranchId({ { 0, "BranchId" } }); // [NodeId]
-QUaBrowsePath QUaConditionBranch::Retain  ({ { 0, "Retain"   } }); // [Boolean]
-QUaBrowsePath QUaConditionBranch::EnabledState               ({ { 0, "EnabledState" } }); // [LocalizedText]
-QUaBrowsePath QUaConditionBranch::EnabledState_Id            ({ { 0, "EnabledState" },{ 0, "Id"             } }); // [Boolean]
-//QUaBrowsePath QUaConditionBranch::EnabledState_FalseState    ({ { 0, "EnabledState" },{ 0, "FalseState"     } }); // [LocalizedText]
-//QUaBrowsePath QUaConditionBranch::EnabledState_TrueState     ({ { 0, "EnabledState" },{ 0, "TrueState"      } }); // [LocalizedText]
-QUaBrowsePath QUaConditionBranch::EnabledState_TransitionTime({ { 0, "EnabledState" },{ 0, "TransitionTime" } }); // [UtcTime]
-QUaBrowsePath QUaConditionBranch::Comment                ({ { 0, "Comment" } }); // [LocalizedText]
-QUaBrowsePath QUaConditionBranch::Comment_SourceTimestamp({ { 0, "Comment" },{0, "SourceTimestamp"} }); // [UtcTime]
+QUaBrowsePath QUaConditionBranch::BranchId({ { 0, QStringLiteral("BranchId") } }); // [NodeId]
+QUaBrowsePath QUaConditionBranch::Retain  ({ { 0, QStringLiteral("Retain")   } }); // [Boolean]
+QUaBrowsePath QUaConditionBranch::EnabledState               ({ { 0, QStringLiteral("EnabledState") } }); // [LocalizedText]
+QUaBrowsePath QUaConditionBranch::EnabledState_Id            ({ { 0, QStringLiteral("EnabledState") },{ 0, QStringLiteral("Id")             } }); // [Boolean]
+//QUaBrowsePath QUaConditionBranch::EnabledState_FalseState    ({ { 0, QStringLiteral("EnabledState") },{ 0, QStringLiteral("FalseState")     } }); // [LocalizedText]
+//QUaBrowsePath QUaConditionBranch::EnabledState_TrueState     ({ { 0, QStringLiteral("EnabledState") },{ 0, QStringLiteral("TrueState")      } }); // [LocalizedText]
+QUaBrowsePath QUaConditionBranch::EnabledState_TransitionTime({ { 0, QStringLiteral("EnabledState") },{ 0, QStringLiteral("TransitionTime") } }); // [UtcTime]
+QUaBrowsePath QUaConditionBranch::Comment                ({ { 0, QStringLiteral("Comment") } }); // [LocalizedText]
+QUaBrowsePath QUaConditionBranch::Comment_SourceTimestamp({ { 0, QStringLiteral("Comment") },{0, QStringLiteral("SourceTimestamp")} }); // [UtcTime]
 
 QUaConditionBranch::QUaConditionBranch(QUaCondition* parent, const QUaNodeId& branchId/* = QUaNodeId()*/)
 {
@@ -937,8 +937,8 @@ void QUaConditionBranch::setComment(const QUaLocalizedText& comment, const QStri
 }
 
 QSet<QUaQualifiedName> ignoreSet = QSet<QUaQualifiedName>()
-<< QUaQualifiedName( 0, "FalseState" )
-<< QUaQualifiedName( 0, "TrueState"  );
+<< QUaQualifiedName( 0, QStringLiteral("FalseState") )
+<< QUaQualifiedName( 0, QStringLiteral("TrueState")  );
 
 void QUaConditionBranch::addChildren(QUaNode* node, const QUaBrowsePath& browsePath/* = QUaBrowsePath()*/)
 {

--- a/src/wrapper/quacustomdatatypes.cpp
+++ b/src/wrapper/quacustomdatatypes.cpp
@@ -87,37 +87,37 @@ QHash<UA_NodeId, QMetaType::Type> QUaDataType::m_custTypesByNodeId = {
 #endif // UA_ENABLE_SUBSCRIPTIONS_EVENTS
 };
 
-QHash<int, QMetaType::Type> QUaDataType::m_custTypesByTypeIndex = {
-	{UA_TYPES_BOOLEAN                     , QMetaType::Bool                  },
-	{UA_TYPES_SBYTE                       , QMetaType::Char                  },
-	//{UA_TYPES_SBYTE                       , QMetaType::SChar                 },
-	{UA_TYPES_BYTE                        , QMetaType::UChar                 },
-	{UA_TYPES_INT16                       , QMetaType::Short                 },
-	{UA_TYPES_UINT16                      , QMetaType::UShort                },
-	{UA_TYPES_INT32                       , QMetaType::Int                   },
-	{UA_TYPES_UINT32                      , QMetaType::UInt                  },
-	{UA_TYPES_INT64                       , QMetaType::Long                  },
-	//{UA_TYPES_INT64                       , QMetaType::LongLong              },
-	{UA_TYPES_UINT64                      , QMetaType::ULong                 },
-	//{UA_TYPES_UINT64                      , QMetaType::ULongLong             },
-	{UA_TYPES_FLOAT                       , QMetaType::Float                 },
-	{UA_TYPES_DOUBLE                      , QMetaType::Double                },
-	{UA_TYPES_STRING                      , QMetaType::QString               },
-	{UA_TYPES_DATETIME                    , QMetaType::QDateTime             },
-	{UA_TYPES_GUID                        , QMetaType::QUuid                 },
-	{UA_TYPES_BYTESTRING                  , QMetaType::QByteArray            },
-	{UA_TYPES_VARIANT                     , QMetaType::QVariant              },
-	{UA_TYPES_NODEID                      , QMetaType_NodeId                 },
-	{UA_TYPES_STATUSCODE                  , QMetaType_StatusCode             },
-	{UA_TYPES_QUALIFIEDNAME               , QMetaType_QualifiedName          },
-	{UA_TYPES_LOCALIZEDTEXT               , QMetaType_LocalizedText          },
+QHash<const UA_DataType*, QMetaType::Type> QUaDataType::m_custTypesByDataType = {
+	{&UA_TYPES[UA_TYPES_BOOLEAN]                     , QMetaType::Bool                  },
+	{&UA_TYPES[UA_TYPES_SBYTE]                       , QMetaType::Char                  },
+	//{&UA_TYPES[UA_TYPES_SBYTE]                       , QMetaType::SChar                 },
+	{&UA_TYPES[UA_TYPES_BYTE]                        , QMetaType::UChar                 },
+	{&UA_TYPES[UA_TYPES_INT16]                       , QMetaType::Short                 },
+	{&UA_TYPES[UA_TYPES_UINT16]                      , QMetaType::UShort                },
+	{&UA_TYPES[UA_TYPES_INT32]                       , QMetaType::Int                   },
+	{&UA_TYPES[UA_TYPES_UINT32]                      , QMetaType::UInt                  },
+	{&UA_TYPES[UA_TYPES_INT64]                       , QMetaType::Long                  },
+	//{&UA_TYPES[UA_TYPES_INT64]                       , QMetaType::LongLong              },
+	{&UA_TYPES[UA_TYPES_UINT64]                      , QMetaType::ULong                 },
+	//{&UA_TYPES[UA_TYPES_UINT64]                      , QMetaType::ULongLong             },
+	{&UA_TYPES[UA_TYPES_FLOAT]                       , QMetaType::Float                 },
+	{&UA_TYPES[UA_TYPES_DOUBLE]                      , QMetaType::Double                },
+	{&UA_TYPES[UA_TYPES_STRING]                      , QMetaType::QString               },
+	{&UA_TYPES[UA_TYPES_DATETIME]                    , QMetaType::QDateTime             },
+	{&UA_TYPES[UA_TYPES_GUID]                        , QMetaType::QUuid                 },
+	{&UA_TYPES[UA_TYPES_BYTESTRING]                  , QMetaType::QByteArray            },
+	{&UA_TYPES[UA_TYPES_VARIANT]                     , QMetaType::QVariant              },
+	{&UA_TYPES[UA_TYPES_NODEID]                      , QMetaType_NodeId                 },
+	{&UA_TYPES[UA_TYPES_STATUSCODE]                  , QMetaType_StatusCode             },
+	{&UA_TYPES[UA_TYPES_QUALIFIEDNAME]               , QMetaType_QualifiedName          },
+	{&UA_TYPES[UA_TYPES_LOCALIZEDTEXT]               , QMetaType_LocalizedText          },
 #ifdef UA_GENERATED_NAMESPACE_ZERO_FULL
-	{UA_TYPES_IMAGEPNG                    , QMetaType_Image                  },
-	{UA_TYPES_OPTIONSET                   , QMetaType_OptionSet              },
+	{&UA_TYPES[UA_TYPES_IMAGEPNG]                    , QMetaType_Image                  },
+	{&UA_TYPES[UA_TYPES_OPTIONSET]                   , QMetaType_OptionSet              },
 #endif // UA_GENERATED_NAMESPACE_ZERO_FULL
 #ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS
-	{UA_TYPES_TIMEZONEDATATYPE            , QMetaType_TimeZone               },
-	{UA_TYPES_MODELCHANGESTRUCTUREDATATYPE, QMetaType_ChangeStructureDataType}
+	{&UA_TYPES[UA_TYPES_TIMEZONEDATATYPE]            , QMetaType_TimeZone               },
+	{&UA_TYPES[UA_TYPES_MODELCHANGESTRUCTUREDATATYPE], QMetaType_ChangeStructureDataType}
 #endif // UA_ENABLE_SUBSCRIPTIONS_EVENTS
 };
 
@@ -211,10 +211,10 @@ QMetaType::Type QUaDataType::qTypeByNodeId(const UA_NodeId& nodeId)
 	return m_custTypesByNodeId.value(nodeId, QMetaType::UnknownType);
 }
 
-QMetaType::Type QUaDataType::qTypeByTypeIndex(const int& typeIndex)
+QMetaType::Type QUaDataType::qTypeByDataType(const UA_DataType* dataType)
 {
-	Q_ASSERT(m_custTypesByTypeIndex.contains(typeIndex));
-	return m_custTypesByTypeIndex.value(typeIndex, QMetaType::UnknownType);
+	Q_ASSERT(m_custTypesByDataType.contains(dataType));
+	return m_custTypesByDataType.value(dataType, QMetaType::UnknownType);
 }
 
 UA_NodeId QUaDataType::nodeIdByQType(const QMetaType::Type& type)
@@ -1443,7 +1443,7 @@ QUaOptionSet::QUaOptionSet(const QString& strXmlOptionSet)
 QUaOptionSet::QUaOptionSet(const char* strXmlOptionSet)
 {
 	// use overloaded equality operator
-	*this = QString(strXmlOptionSet);
+	*this = QString::fromUtf8(strXmlOptionSet);
 	Q_ASSERT(m_value.size() == 8);
 	Q_ASSERT(m_validBits.size() == 8);
 }
@@ -1506,7 +1506,7 @@ void QUaOptionSet::operator=(const QString& strXmlOptionSet)
 void QUaOptionSet::operator=(const char* strXmlOptionSet)
 {
 	// use overloaded equality operator
-	*this = QString(strXmlOptionSet);
+	*this = QString::fromUtf8(strXmlOptionSet);
 }
 
 void QUaOptionSet::operator=(const QUaOptionSet& other)

--- a/src/wrapper/quacustomdatatypes.h
+++ b/src/wrapper/quacustomdatatypes.h
@@ -396,16 +396,16 @@ public:
 
     static bool               isSupportedQType(const QMetaType::Type& type);
     static QMetaType::Type    qTypeByNodeId   (const UA_NodeId &nodeId);
-    static QMetaType::Type    qTypeByTypeIndex(const int& typeIndex);
+    static QMetaType::Type    qTypeByDataType (const UA_DataType* dataType);
     static UA_NodeId          nodeIdByQType   (const QMetaType::Type& type);
     static const UA_DataType* dataTypeByQType (const QMetaType::Type& type);
     static QString            stringByQType   (const QMetaType::Type& type);
 
 private:
     QMetaType::Type m_type;
-    static QHash<QString  , QMetaType::Type> m_custTypesByName;
-    static QHash<UA_NodeId, QMetaType::Type> m_custTypesByNodeId;
-    static QHash<int      , QMetaType::Type> m_custTypesByTypeIndex;
+    static QHash<QString,            QMetaType::Type> m_custTypesByName;
+    static QHash<UA_NodeId,          QMetaType::Type> m_custTypesByNodeId;
+    static QHash<const UA_DataType*, QMetaType::Type> m_custTypesByDataType;
     struct TypeData
     {
         QString            name;

--- a/src/wrapper/quahistorybackend.h
+++ b/src/wrapper/quahistorybackend.h
@@ -151,7 +151,7 @@ private:
 
 	// helpers
 	static QUaHistoryDataPoint dataValueToPoint(const UA_DataValue *value);
-	static UA_DataValue dataPointToValue(const QUaHistoryDataPoint *point);
+	static UA_DataValue dataPointToValue(const QUaHistoryDataPoint& point);
 	static void processServerLog(QUaServer* server, QQueue<QUaLog>& logOut);
 	static QMetaType::Type QVariantToQtType(const QVariant& value);
 	static void fixOutputVariantType(QVariant& value, const QMetaType::Type& metaType);

--- a/src/wrapper/quanode.cpp
+++ b/src/wrapper/quanode.cpp
@@ -72,7 +72,7 @@ struct QUaInMemorySerializer
 		qDebug() << header;
 		auto listNodeIds = m_hashNodeTreeData.keys();
 		std::sort(listNodeIds.begin(), listNodeIds.end(),
-		[this, server](const QUaNodeId& nodeId1, const QUaNodeId& nodeId2) -> bool {
+		[server](const QUaNodeId& nodeId1, const QUaNodeId& nodeId2) -> bool {
 			QString browse1 = QUaQualifiedName::reduceXml(server->nodeById(nodeId1)->nodeBrowsePath());
 			QString browse2 = QUaQualifiedName::reduceXml(server->nodeById(nodeId2)->nodeBrowsePath());
 			return browse1 < browse2;
@@ -149,7 +149,6 @@ QUaNode::QUaNode(
 	// list meta props
 	int propCount  = metaObject.propertyCount();
 	int propOffset = QUaNode::getPropsOffsetHelper(metaObject);
-	int numProps   = 0;
 	for (int i = propOffset; i < propCount; i++)
 	{
 		QMetaProperty metaProperty = metaObject.property(i);
@@ -169,8 +168,6 @@ QUaNode::QUaNode(
 			if (propMetaObject->inherits(&metaObject))
 			{ continue; }
 		}
-		// inc number of valid props
-		numProps++;
 		// the Qt meta property name must match the UA browse name
 		QUaQualifiedName browseName = QString::fromUtf8(metaProperty.name());
 		Q_ASSERT(mapChildren.contains(browseName));

--- a/src/wrapper/quanode.cpp
+++ b/src/wrapper/quanode.cpp
@@ -1263,7 +1263,11 @@ QUaNode* QUaNode::cloneNode(
 	auto tmp = QUaNode::getNodeContext(newInstanceNodeId, m_qUaServer->m_server);
 	QUaNode* newInstance = qobject_cast<QUaNode*>(tmp);
 	Q_CHECK_PTR(newInstance);
+
+#if UA_OPEN62541_VER_MINOR < 3
 	UA_NodeId_clear(&newInstanceNodeId);
+#endif
+
 	if (!newInstance)
 	{
 		return newInstance;

--- a/src/wrapper/quaoptionset.cpp
+++ b/src/wrapper/quaoptionset.cpp
@@ -118,7 +118,7 @@ void QUaServer::registerOptionSet(const QString& strOptionSetName, const QUaOpti
 			vectOptionSetValues[b] = { "", "" };
 		}
 	}
-	Q_ASSERT(vectOptionSetValues.count() == maxBit);
+	Q_ASSERT(vectOptionSetValues.count() == static_cast<long long>(maxBit));
 	st = QUaServer::addOptionSetValues(m_server, &reqNodeId, maxBit, vectOptionSetValues.data());
 	Q_ASSERT(st == UA_STATUSCODE_GOOD);
 	// finally append to map

--- a/src/wrapper/quaserver.cpp
+++ b/src/wrapper/quaserver.cpp
@@ -607,17 +607,6 @@ bool QUaServer::isNodeBound(const UA_NodeId & nodeId, UA_Server *server)
 	return true;
 }
 
-extern "C" {
-	typedef UA_StatusCode(*UA_exchangeEncodeBuffer)(void *handle, UA_Byte **bufPos,
-		const UA_Byte **bufEnd);
-
-	UA_EXPORT extern UA_StatusCode
-		UA_encodeBinary(const void *src, const UA_DataType *type,
-			UA_Byte **bufPos, const UA_Byte **bufEnd,
-			UA_exchangeEncodeBuffer exchangeCallback,
-			void *exchangeHandle) UA_FUNC_ATTR_WARN_UNUSED_RESULT;
-}
-
 QUaServer * QUaServer::getServerNodeContext(UA_Server * server)
 {
 	auto context = QUaNode::getVoidContext(UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER), server);

--- a/src/wrapper/quaserver.h
+++ b/src/wrapper/quaserver.h
@@ -755,7 +755,9 @@ inline T * QUaServer::createInstance(
 	Q_CHECK_PTR(newInstance);
     Q_ASSERT(newInstance->parent() == parentNode);
 	// return c++ instance
+#if UA_OPEN62541_VER_MINOR < 3
 	UA_NodeId_clear(&newInstanceNodeId);
+#endif
 	return newInstance;
 }
 
@@ -1292,7 +1294,9 @@ inline bool QUaNode::deserializeInternal(
         // get new c++ instance created in UA constructor
         auto instance = QUaNode::getNodeContext(newInstanceNodeId, this->m_qUaServer->m_server);
         // return c++ instance
+#if UA_OPEN62541_VER_MINOR < 3
         UA_NodeId_clear(&newInstanceNodeId);
+#endif
         // deserialize (recursive)
         bool ok = instance->deserializeInternal<T>(
             deserializer,


### PR DESCRIPTION
This does not affect QUaServer with open62541 version 1.2

In addition, unused variables have been removed, compiler warnings have been eliminated, deprecated Qt methods have been replaced. This is something I didn't notice earlier due to the fact that I compiled without UA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS.

I tested on Windows 10, Clang 16.05, Qt 5.15.9 and 6.5.1 with two versions of open62541 1.2.7 and 1.3.6. Tested examples: 01_basics - no problem
04_types - no problem
08_events - no problem if open62541 1.2 or open62541 1.3, but the latter is built without ALARMS_CONDITIONS.
09_serialization - no problem if open62541 1.2. Doesn't work with open62541 1.3, I couldn't figure it out, need your help.

I did not check 10_historizing, because this example did not work for me before, probably because of Clang or I'm doing something wrong. Please check this example.